### PR TITLE
Elasticsearch 필터 손보기

### DIFF
--- a/src/main/java/com/jakduk/batch/job/InitElasticsearchIndexConfig.java
+++ b/src/main/java/com/jakduk/batch/job/InitElasticsearchIndexConfig.java
@@ -2,12 +2,6 @@ package com.jakduk.batch.job;
 
 import javax.annotation.Resource;
 
-import com.jakduk.batch.configuration.JakdukProperties;
-import com.jakduk.batch.service.SearchService;
-
-import lombok.extern.slf4j.Slf4j;
-
-import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -19,6 +13,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.jakduk.batch.configuration.JakdukProperties;
+import com.jakduk.batch.service.SearchService;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 엘라스틱서치의 인덱스, 타입, 도큐먼트를 지우고 새로 만든다.
@@ -88,10 +87,9 @@ public class InitElasticsearchIndexConfig {
 				searchService.createIndexGallery();
 
 				// search-word 는 인덱스를 새로 만들지 않음. 따라서 기존할 경우, skip 함
-				try {
+				String indexSearchWord = elasticsearchProperties.getIndexSearchWord();
+				if (! searchService.existsIndex(indexSearchWord)) {
 					searchService.createIndexSearchWord();
-				} catch (ResourceAlreadyExistsException e) {
-					log.warn("Index: {}, {}, {}", e.status().name(), e.getIndex(), e.getDetailedMessage());
 				}
 
 				return RepeatStatus.FINISHED;

--- a/src/main/java/com/jakduk/batch/service/SearchService.java
+++ b/src/main/java/com/jakduk/batch/service/SearchService.java
@@ -1,6 +1,8 @@
 package com.jakduk.batch.service;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -365,8 +367,11 @@ public class SearchService {
 			.put("index.analysis.tokenizer.korean_nori_tokenizer.type", "nori_tokenizer")
 			.put("index.analysis.tokenizer.korean_nori_tokenizer.decompound_mode", "none")
 			.putList("index.analysis.tokenizer.korean_nori_tokenizer.user_dictionary_rules", userWords)
+			.put("index.analysis.filter.part_of_speech_stop_sp.type", "nori_part_of_speech")
+			.putList("index.analysis.filter.part_of_speech_stop_sp.stoptags", Arrays.asList("SP"))
 			.put("index.analysis.analyzer.korean.type", "custom")
 			.put("index.analysis.analyzer.korean.tokenizer", "korean_nori_tokenizer")
+			.putList("index.analysis.analyzer.korean.filter", Arrays.asList("part_of_speech_stop_sp", "lowercase"))
 			.build();
 	}
 

--- a/src/main/java/com/jakduk/batch/service/SearchService.java
+++ b/src/main/java/com/jakduk/batch/service/SearchService.java
@@ -340,7 +340,7 @@ public class SearchService {
 	}
 
 	private Settings getIndexSettings() {
-		String[] userWords = new String[] {
+		List<String> userWords = Arrays.asList(
 			"k리그",
 			"k리그1",
 			"k리그2",
@@ -348,7 +348,6 @@ public class SearchService {
 			"k4리그",
 			"성남fc",
 			"수원fc",
-			"인천utd",
 			"인천유나이티드",
 			"강원fc",
 			"fc서울",
@@ -360,18 +359,28 @@ public class SearchService {
 			"제주utd",
 			"제주유나이티드",
 			"서울e"
-		};
+		);
+
+		List<String> synonyms = Arrays.asList(
+			"성남 => 성남fc",
+			"인천utd, 인천 => 인천유나이티드"
+		);
+
+		List<String> analyzerFilters = Arrays.asList(
+			"lowercase",
+			"synonym_graph"
+		);
 
 		// SEE: https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/analysis-nori-tokenizer.html
 		return Settings.builder()
 			.put("index.analysis.tokenizer.korean_nori_tokenizer.type", "nori_tokenizer")
 			.put("index.analysis.tokenizer.korean_nori_tokenizer.decompound_mode", "none")
 			.putList("index.analysis.tokenizer.korean_nori_tokenizer.user_dictionary_rules", userWords)
-			.put("index.analysis.filter.part_of_speech_stop_sp.type", "nori_part_of_speech")
-			.putList("index.analysis.filter.part_of_speech_stop_sp.stoptags", Arrays.asList("SP"))
+			.put("index.analysis.filter.synonym_graph.type", "synonym_graph")
+			.putList("index.analysis.filter.synonym_graph.synonyms", synonyms)
 			.put("index.analysis.analyzer.korean.type", "custom")
 			.put("index.analysis.analyzer.korean.tokenizer", "korean_nori_tokenizer")
-			.putList("index.analysis.analyzer.korean.filter", Arrays.asList("part_of_speech_stop_sp", "lowercase"))
+			.putList("index.analysis.analyzer.korean.filter", analyzerFilters)
 			.build();
 	}
 


### PR DESCRIPTION
## 목표
* 대문자를 모두 소문자로 바꾸고
* 동의어 적용하기
## 테스트
동의어는 잘 되는데, 소문자로 바꾸는건 의도대로 안된다.
나중에 search 쿼리 날릴때 다시 한번 보자
```bash
curl --location --request GET 'http://192.168.0.18:9200/jakduk_dev_board/_analyze' \
--header 'Content-Type: application/json' \
--data-raw '{
  "analyzer": "korean",
  "text": "성남 인천 경남FC k리그"  
}'
```
```json
{
    "tokens": [
        {
            "token": "성남fc",
            "start_offset": 0,
            "end_offset": 2,
            "type": "SYNONYM",
            "position": 0
        },
        {
            "token": "인천유나이티드",
            "start_offset": 3,
            "end_offset": 5,
            "type": "SYNONYM",
            "position": 1
        },
        {
            "token": "경남",
            "start_offset": 6,
            "end_offset": 8,
            "type": "word",
            "position": 2
        },
        {
            "token": "fc",
            "start_offset": 8,
            "end_offset": 10,
            "type": "word",
            "position": 3
        },
        {
            "token": "k리그",
            "start_offset": 11,
            "end_offset": 14,
            "type": "word",
            "position": 4
        }
    ]
}
```  